### PR TITLE
fix: 错字修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /downloads
+
+.idea

--- a/fast-down/src/core/prefetch.rs
+++ b/fast-down/src/core/prefetch.rs
@@ -232,7 +232,7 @@ mod tests {
         match get_url_info(&format!("{}/404", server.url()), &client) {
             Ok(info) => assert!(false, "404 status code should not success: {:?}", info),
             Err(err) => {
-                let err = err.downcast::<reqwest::Error>().expect("reqwest error");
+                let err = err.downcast::<reqwest::Error>().expect("request error");
                 assert!(err.is_status(), "should be error about status code");
                 assert_eq!(err.status(), Some(StatusCode::NOT_FOUND));
             }


### PR DESCRIPTION
修复 fast-down/src/core/prefetch.rs:235 中拼写错误
并附上 Jetbrains RustRover 的 .gitignore 项目